### PR TITLE
flarum-sticky: Fix incorrect translation

### DIFF
--- a/locale/flarum-sticky.yml
+++ b/locale/flarum-sticky.yml
@@ -13,7 +13,7 @@ flarum-sticky:
       sticky_button: '=> flarum-sticky.ref.sticky'
       unsticky_button: 'Sabitten kaldır'
     post_stream:
-      discussion_stickied_text: '{username}, tartışmayı {time} askıya aldı.'
-      discussion_unstickied_text: '{username}, tartışmayı {time} kaldırdı.'
+      discussion_stickied_text: '{username} bu tartışmayı {time} sabitledi.'
+      discussion_unstickied_text: '{username}, {time} bu tartışmanın sabitlenmesini kaldırdı.'
   ref:
     sticky: Sabitle


### PR DESCRIPTION
This PR fixes incorrect translations on `flarum-sticky` extension
